### PR TITLE
Changed getRootDir() to getProjectDir()

### DIFF
--- a/src/main/java/org/veil/gradle/plugins/jmeter/JmeterPluginConvention.java
+++ b/src/main/java/org/veil/gradle/plugins/jmeter/JmeterPluginConvention.java
@@ -87,7 +87,7 @@ public class JmeterPluginConvention {
 
     public JmeterPluginConvention(Project project) {
         reportDir = new File(project.getBuildDir(), "jmeter-report");
-        srcDir = new File(project.getRootDir(), "src/test/jmeter");
+        srcDir = new File(project.getProjectDir(), "src/test/jmeter");
     }
 
     public List<File> getJmeterTestFiles() {

--- a/src/main/java/org/veil/gradle/plugins/jmeter/JmeterRunTask.java
+++ b/src/main/java/org/veil/gradle/plugins/jmeter/JmeterRunTask.java
@@ -221,7 +221,7 @@ public class JmeterRunTask extends ConventionTask {
              args.addAll(Arrays.asList("-n",
                      "-t", testFile.getCanonicalPath(),
                      "-l", resultFile.getCanonicalPath(),
-                     "-d", getProject().getRootDir().getCanonicalPath(),
+                     "-d", getProject().getProjectDir().getCanonicalPath(),
                      "-p", srcDir + File.separator + JMETER_DEFAULT_PROPERTY_NAME));
 
             initUserProperties(args);


### PR DESCRIPTION
When using the jmeter-gradle-plugin in a multimodule project, the jmeter files will be read from <root project>/src/test/jmeter. I was expecting when the plugin runs from a subproject, the files will be read from <sub project>/src/test/jmeter.

BTW: thanks for writing this gradle plugin!
