### PR TITLE
add jmeterPropertyFile parameter

### DIFF
--- a/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterAbstractTask.groovy
+++ b/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterAbstractTask.groovy
@@ -31,7 +31,7 @@ abstract class JmeterAbstractTask extends ConventionTask{
      */
     private File srcDir;
 
-    public static final String JMETER_DEFAULT_PROPERTY_NAME = "jmeter.properties";
+    private File jmeterPropertyFile;
 
     @TaskAction
     public void start() {
@@ -46,6 +46,7 @@ abstract class JmeterAbstractTask extends ConventionTask{
     protected abstract void runTaskAction() throws IOException;
 
     protected void loadPropertiesFromConvention() {
+        jmeterPropertyFile = getJmeterPropertyFile()
         jmeterPluginJars = getJmeterPluginJars()
         jmeterUserProperties = getJmeterUserProperties()
         srcDir = getSrcDir()
@@ -211,5 +212,13 @@ abstract class JmeterAbstractTask extends ConventionTask{
 
     void setSrcDir(File srcDir) {
         this.srcDir = srcDir
+    }
+
+    File getJmeterPropertyFile() {
+        this.jmeterPropertyFile
+    }
+
+    void setJmeterPropertyFile(File jmeterPropertyFile) {
+        this.jmeterPropertyFile = jmeterPropertyFile
     }
 }

--- a/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterPlugin.java
+++ b/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterPlugin.java
@@ -122,6 +122,12 @@ public class JmeterPlugin implements Plugin<Project> {
                 return jmeterConvention.getJmeterPluginJars();
             }
         });
+
+        jmeterRunTask.getConventionMapping().map("jmeterPropertyFile", new Callable<Object>() {
+            public Object call() throws Exception {
+                return jmeterConvention.getJmeterPropertyFile();
+            }
+        });
     }
 
     private void configureJmeterTask(Project project, final JmeterPluginConvention jmeterConvention, JmeterRunGuiTask jmeterRunTask) {

--- a/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterPluginConvention.java
+++ b/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterPluginConvention.java
@@ -87,9 +87,14 @@ public class JmeterPluginConvention {
 
     private List<String> jmeterPluginJars;
 
+    private File jmeterPropertyFile;
+
+    private static final String JMETER_DEFAULT_PROPERTY_NAME = "jmeter.properties";
+
     public JmeterPluginConvention(Project project) {
         reportDir = new File(project.getBuildDir(), "jmeter-report");
         srcDir = new File(project.getProjectDir(), "src/test/jmeter");
+        jmeterPropertyFile = new File(srcDir.getAbsolutePath() + File.separator + JMETER_DEFAULT_PROPERTY_NAME);
     }
 
     public List<File> getJmeterTestFiles() {
@@ -189,10 +194,19 @@ public class JmeterPluginConvention {
     }
     
     public List<String> getJmeterPluginJars() {
-		return jmeterPluginJars;
-	}
+        return jmeterPluginJars;
+    }
     
     public void setJmeterPluginJars(List<String> jmeterPluginJars) {
-		this.jmeterPluginJars = jmeterPluginJars;
-	}
+        this.jmeterPluginJars = jmeterPluginJars;
+    }
+
+    public File getJmeterPropertyFile() {
+        return this.jmeterPropertyFile;
+    }
+
+    public void setJmeterPropertyFile(File jmeterPropertyFile) {
+        this.jmeterPropertyFile = jmeterPropertyFile;
+    }
 }
+

--- a/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterRunGuiTask.groovy
+++ b/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterRunGuiTask.groovy
@@ -14,7 +14,7 @@ class JmeterRunGuiTask extends JmeterAbstractTask{
             List<String> args = new ArrayList<String>();
             args.addAll(Arrays.asList(
                     "-d", getProject().getProjectDir().getCanonicalPath(),
-                    "-p", srcDir.getAbsolutePath() + File.separator + JMETER_DEFAULT_PROPERTY_NAME));
+                    "-p", getJmeterPropertyFile().getCanonicalPath()));
 
             initUserProperties(args);
 
@@ -69,6 +69,4 @@ class JmeterRunGuiTask extends JmeterAbstractTask{
         }
         return testEnded;
     }
-
-
 }

--- a/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterRunTask.java
+++ b/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterRunTask.java
@@ -203,7 +203,7 @@ public class JmeterRunTask extends JmeterAbstractTask {
                      "-t", testFile.getCanonicalPath(),
                      "-l", resultFile.getCanonicalPath(),
                      "-d", getProject().getProjectDir().getCanonicalPath(),
-                     "-p", getSrcDir().getAbsolutePath() + File.separator + JMETER_DEFAULT_PROPERTY_NAME));
+                     "-p", getJmeterPropertyFile().getCanonicalPath()));
 
             initUserProperties(args);
 


### PR DESCRIPTION
adds the ability to specify an alternate properties file for the -p option JmeterPropertyFile 

it defaults to the current location within srcDir.  
