### PR TITLE
Increase resolution of timestamp on resultFile

### DIFF
--- a/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterRunTask.java
+++ b/src/main/groovy/org/veil/gradle/plugins/jmeter/JmeterRunTask.java
@@ -93,7 +93,7 @@ public class JmeterRunTask extends JmeterAbstractTask {
      */
     private File reportXslt;
 
-    private DateFormat fmt = new SimpleDateFormat("yyyyMMdd");
+    private DateFormat fmt = new SimpleDateFormat("yyyyMMdd-HHmm");
 
     @Override
     protected void runTaskAction() throws IOException {


### PR DESCRIPTION
Increase resolution of timestamp on resultFile so that more than one jmeterRunTask can be executed by gradle within an hour.
